### PR TITLE
fix: pnpm native patch for react-native-peripheral android

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "hdcx-sample-wallet",
   "main": "expo-router/entry",
   "version": "0.1.0",
+  "pnpm": {
+    "patchedDependencies": {
+      "react-native-peripheral": "patches/react-native-peripheral.patch"
+    }
+  },
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",

--- a/patches/react-native-peripheral.patch
+++ b/patches/react-native-peripheral.patch
@@ -1,0 +1,47 @@
+diff --git a/android/build.gradle b/android/build.gradle
+index b01733b465a135cd1854e29994cbe9aa88e221f0..0dd698cb0e36024d895a012b1444d1558e25993b 100644
+--- a/android/build.gradle
++++ b/android/build.gradle
+@@ -20,7 +20,7 @@ buildscript {
+ }
+ 
+ apply plugin: 'com.android.library'
+-apply plugin: 'maven'
++apply plugin: 'maven-publish'
+ 
+ // Matches values in recent template from React Native 0.59 / 0.60
+ // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9
+@@ -99,17 +99,16 @@ afterEvaluate { project ->
+     task androidJavadoc(type: Javadoc) {
+         source = android.sourceSets.main.java.srcDirs
+         classpath += files(android.bootClasspath)
+-        classpath += files(project.getConfigurations().getByName('compile').asList())
+         include '**/*.java'
+     }
+ 
+     task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {
+-        classifier = 'javadoc'
++        archiveClassifier = 'javadoc'
+         from androidJavadoc.destinationDir
+     }
+ 
+     task androidSourcesJar(type: Jar) {
+-        classifier = 'sources'
++        archiveClassifier = 'sources'
+         from android.sourceSets.main.java.srcDirs
+         include '**/*.java'
+     }
+@@ -125,13 +124,4 @@ afterEvaluate { project ->
+         archives androidSourcesJar
+         archives androidJavadocJar
+     }
+-
+-    task installArchives(type: Upload) {
+-        configuration = configurations.archives
+-        repositories.mavenDeployer {
+-            // Deploy to react-native-event-bridge/maven, ready to publish to npm
+-            repository url: "file://${projectDir}/../android/maven"
+-            configureReactNativePom pom
+-        }
+-    }
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  react-native-peripheral:
+    hash: iiw2glxebjbiryi774ge5b6ofm
+    path: patches/react-native-peripheral.patch
+
 importers:
 
   .:
@@ -145,7 +150,7 @@ importers:
         version: 3.16.1
       react-native-peripheral:
         specifier: ^0.0.3
-        version: 0.0.3(react-native@0.79.2(@babel/core@7.27.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+        version: 0.0.3(patch_hash=iiw2glxebjbiryi774ge5b6ofm)(react-native@0.79.2(@babel/core@7.27.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react-native-reanimated:
         specifier: ~3.17.5
         version: 3.17.5(@babel/core@7.27.4)(react-native@0.79.2(@babel/core@7.27.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
@@ -9176,7 +9181,7 @@ snapshots:
 
   react-native-nfc-manager@3.16.1: {}
 
-  react-native-peripheral@0.0.3(react-native@0.79.2(@babel/core@7.27.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
+  react-native-peripheral@0.0.3(patch_hash=iiw2glxebjbiryi774ge5b6ofm)(react-native@0.79.2(@babel/core@7.27.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
     dependencies:
       react: 19.0.0
       react-native: 0.79.2(@babel/core@7.27.4)(@types/react@19.0.14)(react@19.0.0)


### PR DESCRIPTION
## Overview
**Issue**: build (`eas build --platform android --profile development`) fails
**Cause**: `react-native-peripheral` uses deprecated Gradle plugin id `'maven'`
**Confirmation**: removing the dependency resolves build failure
**Reason to patch**: `react-native-peripheral` is used by the Sample Verifier's BLE peripheral/advertising mode

## Instructions
1. `pnpm install`
1. Create a patch: `pnpm patch react-native-peripheral`
1. Modify `node_modules/.pnpm_patches/react-native-peripheral@0.0.3/android/build.gradle`
1. Commit the patch: `pnpm patch-commit node_modules/.pnpm_patches/react-native-peripheral@0.0.3`
1. Delete generated `pnpm-workspace.yaml`
1. Add patch config to `package.json` matching  auto-generated `patchedDependencies` section in `pnpm-lock.yaml`
1. Sync lockfile (once): `pnpm install --no-frozen-lockfile`
1. Verify: `pnpm install --frozen-lockfile` 
1. `eas build --platform android --profile development`