### PR TITLE
fix: fix pnpm version to fix patch's hash format conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "hdcx-sample-wallet",
   "main": "expo-router/entry",
   "version": "0.1.0",
+  "packageManager": "pnpm@9.12.0",
   "pnpm": {
     "patchedDependencies": {
       "react-native-peripheral": "patches/react-native-peripheral.patch"


### PR DESCRIPTION
Seems like pnpm version difference was causing issue with patch's hash in `pnpm-lock.yaml`.